### PR TITLE
fix: auto-create competition_profile on signup to fix ranking visibility

### DIFF
--- a/supabase/migrations/20260414120000_auto_competition_profile_on_signup.sql
+++ b/supabase/migrations/20260414120000_auto_competition_profile_on_signup.sql
@@ -1,0 +1,37 @@
+-- ================================================================
+-- Fix: users who sign up after competition_profiles bulk insert
+-- are not visible in the ranking.
+--
+-- 1. Backfill any profiles missing a competition_profiles entry
+--    for the currently active competition.
+-- 2. Add a trigger on profiles so every new signup automatically
+--    gets a competition_profiles row for every active competition.
+-- ================================================================
+
+-- 1. Backfill missing entries
+INSERT INTO competition_profiles (competition_id, user_id, score)
+SELECT c.id, p.id, 0
+FROM competitions c
+CROSS JOIN profiles p
+WHERE c.active = true
+ON CONFLICT (competition_id, user_id) DO NOTHING;
+
+-- 2. Trigger function: create competition_profiles on new profile
+CREATE OR REPLACE FUNCTION handle_new_profile()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO competition_profiles (competition_id, user_id, score)
+  SELECT c.id, NEW.id, 0
+  FROM competitions c
+  WHERE c.active = true
+  ON CONFLICT (competition_id, user_id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS on_profile_created ON profiles;
+CREATE TRIGGER on_profile_created
+  AFTER INSERT ON profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION handle_new_profile();


### PR DESCRIPTION
Users who register after the initial competition_profiles bulk insert
were missing from the ranking view entirely. The recent scoring trigger
refactor (20260409) switched from UPSERT to UPDATE, removing the last
safety net that would have created their row on first scored bet.

This migration:
- Backfills competition_profiles for any existing profiles that lack
  an entry for the active competition (e.g. Thibaud)
- Adds a trigger on profiles so every new signup automatically gets
  a competition_profiles row for all active competitions

https://claude.ai/code/session_01PkvwsBRgCguW3SDUgcFW5U

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a data backfill plus a `SECURITY DEFINER` trigger on `profiles` inserts; mistakes could create unexpected rows across active competitions or impact signup performance.
> 
> **Overview**
> Fixes missing ranking entries for users who sign up after the initial `competition_profiles` population by backfilling any missing `(competition_id, user_id)` rows for *active* competitions.
> 
> Adds a new `AFTER INSERT` trigger on `profiles` (`handle_new_profile`) that automatically inserts a zero-score `competition_profiles` row for each active competition on every new signup (idempotent via `ON CONFLICT DO NOTHING`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e92fcdefccbe99b38aff2f3f60d3f608f15b1219. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->