### PR TITLE
perf(supabase): reduce disk IO from notify-pre-match cron

### DIFF
--- a/supabase/functions/notify-pre-match/index.ts
+++ b/supabase/functions/notify-pre-match/index.ts
@@ -62,7 +62,7 @@ Deno.serve(async (_req: Request) => {
   const supabase = createClient(supabaseUrl, serviceKey);
   const now = new Date();
   const winStart = new Date(now.getTime() + 4 * 60 * 1000);
-  const winEnd = new Date(now.getTime() + 5 * 60 * 1000);
+  const winEnd = new Date(now.getTime() + 9 * 60 * 1000);
 
   try {
     const { data: rows, error: qErr } = await supabase

--- a/supabase/migrations/20260506120000_reduce_disk_io_cron_and_purge.sql
+++ b/supabase/migrations/20260506120000_reduce_disk_io_cron_and_purge.sql
@@ -1,0 +1,39 @@
+-- Reduce disk IO: lower notify-pre-match cron frequency, purge cron/pg_net history, add partial index
+
+-- 1. Reschedule notify-pre-match: every 5 min during match hours (0-4 + 15-23 UTC)
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE jobname = 'notify-pre-match-cron';
+
+SELECT cron.schedule(
+  'notify-pre-match-cron',
+  '*/5 0-4,15-23 * * *',
+  $$
+  SELECT net.http_post(
+    url := 'https://mpsaxiwzscaekahzwjlq.supabase.co/functions/v1/notify-pre-match',
+    body := '{}'::jsonb,
+    headers := '{"Content-Type": "application/json"}'::jsonb
+  );
+  $$
+);
+
+-- 2. Daily purge of pg_net + pg_cron history
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE jobname = 'purge-cron-net-history';
+
+SELECT cron.schedule(
+  'purge-cron-net-history',
+  '0 5 * * *',
+  $$
+  DELETE FROM net._http_response WHERE created < now() - interval '2 days';
+  DELETE FROM cron.job_run_details WHERE end_time < now() - interval '2 days';
+  $$
+);
+
+-- 3. Partial index matching the notify-pre-match query
+CREATE INDEX IF NOT EXISTS idx_matches_pre_match_window
+  ON public.matches (date_time)
+  WHERE finished = false
+    AND visible_to_users = true
+    AND pre_match_reminder_sent_at IS NULL;


### PR DESCRIPTION
## Summary
- Drop `notify-pre-match-cron` from `* * * * *` to `*/5 0-4,15-23 * * *` (1440 → 168 runs/day, 88% cut)
- Widen notification window in `notify-pre-match` edge function from 4-5 min to 4-9 min (compensates 5-min cron gap)
- Add daily `purge-cron-net-history` job (cleans `net._http_response` + `cron.job_run_details` older than 2 days)
- Add partial index `idx_matches_pre_match_window` matching the cron query

## Why
Project hit Disk IO Budget warning. Investigation showed:
- `net._http_response` = 70 MB (pg_net stores response bodies of every HTTP call)
- `cron.job_run_details` = 24 MB / 70k rows (every-minute cron logged for ~49 days)
- Active data tiny (matches=117 rows, bets=254). Bloat was 95% of DB size.

DB changes already applied via migration. Edge function redeploy needs this merge to trigger GitHub Actions.

## Match-hours scope
North America CDM 2026 kickoffs reach 04:00 UTC. Cron active 0-4 + 15-23 UTC, idle 5-14 UTC (no match starts in that window).

## Test plan
- [ ] Verify deploy workflow runs cleanly on merge
- [ ] Confirm `notify-pre-match-cron` schedule shows `*/5 0-4,15-23 * * *` in `cron.job` post-deploy (already applied via MCP — should be no-op)
- [ ] Watch a real pre-match window (next match within 4-9 min) to confirm push notif still fires
- [ ] After 24h, check `net._http_response` and `cron.job_run_details` row counts stay bounded

🤖 Generated with [Claude Code](https://claude.com/claude-code)