### PR TITLE
Déplacer l’Italie vers la Coupe du Monde (migration)

### DIFF
--- a/supabase/migrations/20260531130000_move_italy_to_world_cup.sql
+++ b/supabase/migrations/20260531130000_move_italy_to_world_cup.sql
@@ -1,0 +1,73 @@
+DO $$
+DECLARE
+  competition_row RECORD;
+  team_row RECORD;
+BEGIN
+  FOR competition_row IN
+    SELECT c.id
+    FROM public.competitions c
+    WHERE c.name ILIKE '%Ligue des champions%'
+       OR c.name ILIKE '%LDC%'
+  LOOP
+    FOR team_row IN
+      SELECT t.id
+      FROM public.teams t
+      WHERE t.competition_id = competition_row.id
+        AND t.code = 'it'
+        AND t.name = 'Italie'
+    LOOP
+      UPDATE public.competitions
+      SET final_winner_team = NULL
+      WHERE id = competition_row.id
+        AND final_winner_team = team_row.id;
+
+      UPDATE public.competition_profiles
+      SET winner_team = NULL
+      WHERE competition_id = competition_row.id
+        AND winner_team = team_row.id;
+
+      DELETE FROM public.teams
+      WHERE id = team_row.id;
+    END LOOP;
+
+    PERFORM public.recompute_final_winner_odds(competition_row.id);
+    PERFORM public.refresh_final_winner_scores(competition_row.id);
+  END LOOP;
+
+  FOR competition_row IN
+    SELECT c.id
+    FROM public.competitions c
+    WHERE c.name ILIKE '%Coupe du Monde%'
+  LOOP
+    INSERT INTO public.teams (
+      id,
+      code,
+      group_name,
+      name,
+      win_odd,
+      elimination,
+      unveiled,
+      competition_id
+    )
+    VALUES (
+      'italy-wildcard-' || competition_row.id::text,
+      'it',
+      'Hors compétition',
+      'Italie',
+      8000::numeric,
+      false,
+      true,
+      competition_row.id
+    )
+    ON CONFLICT (id) DO UPDATE SET
+      code = EXCLUDED.code,
+      group_name = EXCLUDED.group_name,
+      name = EXCLUDED.name,
+      elimination = EXCLUDED.elimination,
+      unveiled = EXCLUDED.unveiled,
+      competition_id = EXCLUDED.competition_id;
+
+    PERFORM public.recompute_final_winner_odds(competition_row.id);
+    PERFORM public.refresh_final_winner_scores(competition_row.id);
+  END LOOP;
+END $$;


### PR DESCRIPTION
### Motivation
- Corriger l’ajout incorrect de l’équipe "Italie" dans la compétition « Ligue des champions / LDC » en la retirant de cette compétition et en la proposant comme option de vainqueur final pour les compétitions « Coupe du Monde ». 
- Préserver l’intégrité référentielle et les scores liés au vainqueur final en réinitialisant d’abord les sélections affectées avant la suppression et en recalculant les cotes/scores après l’opération.

### Description
- Ajout d’une migration corrective `supabase/migrations/20260531130000_move_italy_to_world_cup.sql` qui identifie les compétitions LDC et Coupe du Monde et opère les changements nécessaires. 
- Pour chaque compétition LDC la migration met à `NULL` `final_winner_team` dans `competitions` et `winner_team` dans `competition_profiles` pour l’équipe `it` nommée `Italie` puis supprime la ligne correspondante dans `teams`. 
- Pour chaque compétition contenant `Coupe du Monde` la migration insert ou met à jour une entrée `italy-wildcard-<competition_id>` avec `code = 'it'`, `name = 'Italie'`, `group_name = 'Hors compétition'` et `win_odd = 8000`, puis appelle `public.recompute_final_winner_odds` et `public.refresh_final_winner_scores` pour rafraîchir cotes et scores.

### Testing
- Exécution de la compilation et du build via `npm run build` (qui lance `tsc --noEmit` puis `vite build`) : succès. 
- Exécution de `npm run prettier:check` : échec pour 33 fichiers préexistants non modifiés par ce changement (formatage existant à corriger indépendamment). 
- Exécution de `git diff --check` : aucune erreur de diff détectée.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4e32a46083318bda7cf467ef644a)