### PR TITLE
Ajout d'un loader lors du chargement du vainqueur final sélectionné

### DIFF
--- a/src/screens/HomePage/FinalWinner/FinalWinner.tsx
+++ b/src/screens/HomePage/FinalWinner/FinalWinner.tsx
@@ -6,7 +6,12 @@ import {
   useCompetitionData,
   useCompetitionDisplayName,
 } from '../../../hooks/competition'
+import Loader from '../../../components/Loader'
 import FinalWinnerChoice from './FinalWinnerChoice'
+
+const finalWinnerLoader = (
+  <Loader label="Chargement du vainqueur final..." size="sm" variant="inline" />
+)
 
 const FinalWinner = () => {
   const [team, saveWinner] = useSelectedWinner()
@@ -28,12 +33,17 @@ const FinalWinner = () => {
   if (!CompetitionStartDate) return null
 
   const locked = isPast(CompetitionStartDate)
+  const winnerLoading = team === undefined
 
   const lockLabel = useMemo(() => {
     if (!competitionData?.start_date) return null
-    return format(new Date(competitionData.start_date), "d MMMM yyyy 'à' HH:mm", {
-      locale: fr,
-    })
+    return format(
+      new Date(competitionData.start_date),
+      "d MMMM yyyy 'à' HH:mm",
+      {
+        locale: fr,
+      },
+    )
   }, [competitionData?.start_date])
 
   return (
@@ -49,13 +59,21 @@ const FinalWinner = () => {
             : `Qui gagnera ${competitionLabel} ?`}
         {!locked && lockLabel != null && (
           <span className="block mt-2 text-gray-500">
-            Clôture des pronostics vainqueur au coup d&apos;envoi du premier quart de finale (
-            {lockLabel}).
+            Clôture des pronostics vainqueur au coup d&apos;envoi du premier
+            quart de finale ({lockLabel}).
           </span>
         )}
       </p>
-      <Suspense fallback={null}>
-        <FinalWinnerChoice userTeam={team} disabled={locked} onTeamSelect={handleTeamSelect} />
+      <Suspense fallback={finalWinnerLoader}>
+        {winnerLoading ? (
+          finalWinnerLoader
+        ) : (
+          <FinalWinnerChoice
+            userTeam={team}
+            disabled={locked}
+            onTeamSelect={handleTeamSelect}
+          />
+        )}
       </Suspense>
     </div>
   )


### PR DESCRIPTION
### Motivation
- Améliorer l'expérience utilisateur en affichant un indicateur visuel pendant la récupération du pronostic "vainqueur final" afin d'éviter un état vide ou une interaction prématurée.

### Description
- Modifié `src/screens/HomePage/FinalWinner/FinalWinner.tsx` pour importer et réutiliser le composant `Loader` comme fallback et affichage inline. 
- Ajouté la constante `finalWinnerLoader` contenant le `Loader` avec le libellé `Chargement du vainqueur final...`. 
- Ajouté le drapeau `winnerLoading` (`team === undefined`) et rendu conditionnel pour afficher le loader tant que `useSelectedWinner()` n'a pas renvoyé la valeur du vainqueur. 
- Utilisation de `Suspense` avec `fallback={finalWinnerLoader}` et rendu du composant `FinalWinnerChoice` uniquement une fois la valeur chargée.

### Testing
- `npm run build` a été exécuté avec succès (production build via Vite). 
- `npx prettier --check src/screens/HomePage/FinalWinner/FinalWinner.tsx` a réussi pour le fichier modifié. 
- `npm run prettier:check` a été exécuté et a échoué en raison de fichiers non formatés préexistants non liés à ce changement. 
- `git diff --check` n'a retourné aucune erreur d'indentation ou whitespace sur les fichiers modifiés.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c543fd88883318f2c734dc9c465cf)