### PR TITLE
Reset World Cup users and groups

### DIFF
--- a/supabase/migrations/20260531140000_reset_world_cup_users_and_groups.sql
+++ b/supabase/migrations/20260531140000_reset_world_cup_users_and_groups.sql
@@ -1,0 +1,35 @@
+BEGIN;
+
+DELETE FROM public.group_apply;
+DELETE FROM public.group_members;
+DELETE FROM public.groups;
+DELETE FROM public.bets;
+DELETE FROM public.competition_profiles;
+DELETE FROM storage.objects
+WHERE bucket_id = 'avatars';
+DELETE FROM public.profiles;
+DELETE FROM auth.users;
+
+DO $$
+DECLARE
+  match_row RECORD;
+  competition_row RECORD;
+BEGIN
+  FOR match_row IN
+    SELECT id
+    FROM public.matches
+    WHERE score_a IS NULL
+      AND (date_time IS NULL OR date_time > NOW())
+  LOOP
+    PERFORM public.recompute_match_odds(match_row.id);
+  END LOOP;
+
+  FOR competition_row IN
+    SELECT id
+    FROM public.competitions
+  LOOP
+    PERFORM public.recompute_final_winner_odds(competition_row.id);
+  END LOOP;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- Provide a clean reset for the World Cup by removing all tribes/groups and user-related data so the competition can start from a neutral state.

### Description
- Add `supabase/migrations/20260531140000_reset_world_cup_users_and_groups.sql` which deletes rows from `group_apply`, `group_members`, `groups`, `bets`, `competition_profiles`, removes avatar `storage.objects` in the `avatars` bucket, deletes `profiles` and `auth.users`, and then recomputes match odds and final-winner odds by calling `public.recompute_match_odds` and `public.recompute_final_winner_odds` for remaining matches and competitions.

### Testing
- Ran `git diff --check` with no issues and ran `npm run build` (TypeScript check + Vite build), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c542626fc8331aaaeffe12a749eb9)