### PR TITLE
Fix storage purge deploy auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,18 +51,27 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -z "$SUPABASE_SERVICE_ROLE_KEY" ]; then
-            echo "SUPABASE_SERVICE_ROLE_KEY secret is required to empty avatars bucket" >&2
+          storage_admin_key="$(
+            curl --fail-with-body --silent --show-error \
+              "https://api.supabase.com/v1/projects/${SUPABASE_PROJECT_ID}/api-keys?reveal=true" \
+              --header "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+              | jq -r '[.[] | select((.type == "legacy" and .name == "service_role") or .type == "secret") | .api_key | select(. != null and . != "")][0] // empty'
+          )"
+
+          if [ -z "$storage_admin_key" ]; then
+            echo "Unable to retrieve a Supabase secret or service_role key" >&2
             exit 1
           fi
+
+          echo "::add-mask::$storage_admin_key"
 
           curl --fail-with-body --silent --show-error \
             --request POST \
             "https://${SUPABASE_PROJECT_ID}.supabase.co/storage/v1/bucket/avatars/empty" \
-            --header "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
-            --header "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}"
+            --header "apikey: ${storage_admin_key}" \
+            --header "Authorization: Bearer ${storage_admin_key}"
         env:
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
       - run: supabase functions deploy update-results --no-verify-jwt
         env:


### PR DESCRIPTION
## Summary
- fetch a Supabase admin API key from the Management API during deploy
- mask the retrieved key before emptying the avatars bucket
- keep the Storage purge on the official bucket empty endpoint

## Testing
- git diff --check